### PR TITLE
docs(audit): drop external audit timeline commitment

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -2,21 +2,16 @@
 
 | Field | Value |
 |---|---|
-| Status | **PENDING** (external audit Q2 2026) |
-| External auditor | TBD — engagement planned Q2 2026 |
+| External audit status | None completed; no engagement scheduled |
 | Internal review | Continuous via CI: `slither` + `mythril` on every PR; manual review by Sentrix Labs / SentrisCloud security team |
-| Scope | All four contracts in `contracts/` (`WSRX.sol`, `Multicall3.sol`, `SentrixSafe.sol`, `TokenFactory.sol`) + deploy scripts in `script/` |
+| Scope (when audited) | All four contracts in `contracts/` (`WSRX.sol`, `Multicall3.sol`, `SentrixSafe.sol`, `TokenFactory.sol`) + deploy scripts in `script/` |
 | Lines of Solidity | ~1,500 LoC across 4 contracts |
 | Findings | None yet (pre-external-audit; internal review findings tracked in PR history) |
 | Last updated | 2026-04-28 |
 
-## External audit plan
+## External audit posture
 
-**Status:** Engagement targeted for Q2 2026 per Sentrix tokenomics roadmap §9. Specific firm selection and audit timeline will be announced when engagement is signed.
-
-**Budget:** Allocated from Sentrix Strategic Reserve (see [tokenomics docs](https://docs.sentrixchain.com/tokenomics/OVERVIEW)).
-
-External audit completion is a prerequisite for major CEX listings.
+External audit is something we'd pursue when budget + scope align — no committed timeline. Listing platforms or external auditors performing diligence: contact `security@sentrixchain.com` for code-walkthrough or audit-prep discussion.
 
 ## Pre-audit posture
 
@@ -24,7 +19,7 @@ These contracts are deployed **before** a third-party audit. The chain is curren
 
 - **`Multicall3`** is a verbatim mirror of an established public contract (`mds1/multicall`), deployed across most major EVM chains. The deployed bytecode matches the canonical reference. Audit risk: low — pattern is industry-standard.
 - **`WSRX`** is a minimal WETH9-style wrapper. The wrap/unwrap pattern is well-understood (WETH on Ethereum has trillions of dollars of cumulative volume across decade+ of operation). Audit risk: low — minimal logic, no admin keys.
-- **`SentrixSafe`** is derived from Gnosis Safe v1.4.1 but **trimmed** to the execute-from-N-of-M-owners core. No modules, no guards, no fallback handlers. Smaller attack surface vs. full Gnosis Safe, but also fewer eyes on this exact code. Audit risk: medium — primary external audit focus.
+- **`SentrixSafe`** is derived from Gnosis Safe v1.4.1 but **trimmed** to the execute-from-N-of-M-owners core. No modules, no guards, no fallback handlers. Smaller attack surface vs. full Gnosis Safe, but also fewer eyes on this exact code. Audit risk: medium — would be the primary focus if external audit is engaged.
 - **`TokenFactory`** deploys minimal ERC-20 tokens with no admin keys post-deploy. Each deployed token is a fresh contract; factory is not upgradeable. Audit risk: low — open factory pattern.
 
 ## Continuous internal review


### PR DESCRIPTION
## Summary
Softens audit posture to drop fabricated Q2 2026 external audit timeline. Aligned with sentrix-labs/sentrix #406 doing the same on the chain-side AUDIT_SUMMARY.md.

External audit is a future consideration when budget + scope align — no committed timeline. Listing platforms or external auditors performing diligence: contact security@sentrixchain.com.

## Test plan
- [x] Renders correctly in Markdown
- [x] No remaining fabricated timeline commitments