### PR TITLE
feat(contracts): MerkleAirdrop — Sentrix airdrop phase claim contract

### DIFF
--- a/contracts/MerkleAirdrop.sol
+++ b/contracts/MerkleAirdrop.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+/// @title MerkleAirdrop
+/// @author Sentrix Labs
+/// @notice Generic merkle-tree airdrop claim contract for Sentrix airdrop phases.
+/// @dev Minimal & immutable: deploy with merkle root + total amount, pre-fund with
+///      native SRX, recipients claim with a merkle proof. After the claim window
+///      expires, the owner sweeps unclaimed balance back to a configured recipient.
+///
+///      Designed for one phase per deploy — Phase 1 (Testnet Heroes) gets its own
+///      MerkleAirdrop instance pre-funded from Strategic Reserve. Subsequent phases
+///      deploy fresh instances.
+///
+///      Tree leaf format: keccak256(abi.encodePacked(address, uint256))
+///      Proof verification follows OpenZeppelin's MerkleProof convention
+///      (sorted siblings).
+contract MerkleAirdrop {
+    // ── Immutable config ─────────────────────────────────────
+    bytes32 public immutable merkleRoot;
+    uint256 public immutable claimDeadline; // unix timestamp; after this, no more claims
+    address public immutable sweepRecipient; // where unclaimed SRX returns (e.g. Strategic Reserve)
+    address public immutable owner; // address allowed to call sweep() after deadline
+
+    // ── State ────────────────────────────────────────────────
+    /// @dev address => has-claimed flag
+    mapping(address => bool) public claimed;
+
+    /// @dev cumulative claimed amount (for accounting / introspection)
+    uint256 public totalClaimed;
+
+    /// @dev set true after sweep() is called; locks any further state changes
+    bool public swept;
+
+    // ── Events ───────────────────────────────────────────────
+    event Claimed(address indexed recipient, uint256 amount);
+    event Swept(address indexed recipient, uint256 amount);
+
+    // ── Errors ───────────────────────────────────────────────
+    error AlreadyClaimed();
+    error InvalidProof();
+    error ClaimWindowClosed();
+    error ClaimWindowOpen();
+    error AlreadySwept();
+    error NotOwner();
+    error TransferFailed();
+    error ZeroAddress();
+
+    // ── Constructor ──────────────────────────────────────────
+    /// @param _merkleRoot Root of the airdrop merkle tree. Leaves are
+    ///        `keccak256(abi.encodePacked(address, uint256))` sorted-pair internal hashes.
+    /// @param _claimDeadline Unix timestamp after which claims are rejected.
+    /// @param _sweepRecipient Address that receives unclaimed balance after sweep().
+    /// @param _owner Address allowed to call sweep() after deadline (typically SentrixSafe).
+    constructor(
+        bytes32 _merkleRoot,
+        uint256 _claimDeadline,
+        address _sweepRecipient,
+        address _owner
+    ) {
+        if (_sweepRecipient == address(0)) revert ZeroAddress();
+        if (_owner == address(0)) revert ZeroAddress();
+        merkleRoot = _merkleRoot;
+        claimDeadline = _claimDeadline;
+        sweepRecipient = _sweepRecipient;
+        owner = _owner;
+    }
+
+    // ── Pre-fund ─────────────────────────────────────────────
+    /// @notice Anyone can fund the contract by sending SRX to it.
+    ///         Typically the Strategic Reserve owner pre-funds at deploy time.
+    receive() external payable {}
+
+    // ── Claim ────────────────────────────────────────────────
+    /// @notice Claim airdrop allocation by submitting a merkle proof.
+    /// @param amount The allocated amount (in wei) for the calling address.
+    /// @param proof Merkle proof showing `(msg.sender, amount)` is in the tree.
+    function claim(uint256 amount, bytes32[] calldata proof) external {
+        if (block.timestamp > claimDeadline) revert ClaimWindowClosed();
+        if (claimed[msg.sender]) revert AlreadyClaimed();
+        if (swept) revert AlreadySwept();
+
+        bytes32 leaf = keccak256(abi.encodePacked(msg.sender, amount));
+        if (!_verify(proof, merkleRoot, leaf)) revert InvalidProof();
+
+        claimed[msg.sender] = true;
+        totalClaimed += amount;
+
+        (bool ok,) = msg.sender.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+
+        emit Claimed(msg.sender, amount);
+    }
+
+    // ── Sweep ────────────────────────────────────────────────
+    /// @notice After claim window closes, sweep remaining balance to sweepRecipient.
+    ///         Only callable by owner. Locks state to prevent re-sweep.
+    function sweep() external {
+        if (msg.sender != owner) revert NotOwner();
+        if (block.timestamp <= claimDeadline) revert ClaimWindowOpen();
+        if (swept) revert AlreadySwept();
+
+        swept = true;
+
+        uint256 balance = address(this).balance;
+        if (balance > 0) {
+            (bool ok,) = sweepRecipient.call{value: balance}("");
+            if (!ok) revert TransferFailed();
+        }
+
+        emit Swept(sweepRecipient, balance);
+    }
+
+    // ── View helpers ─────────────────────────────────────────
+    /// @notice Check whether `account` is eligible (proof valid) without claiming.
+    function isEligible(address account, uint256 amount, bytes32[] calldata proof)
+        external
+        view
+        returns (bool)
+    {
+        bytes32 leaf = keccak256(abi.encodePacked(account, amount));
+        return _verify(proof, merkleRoot, leaf);
+    }
+
+    // ── Merkle verification (OpenZeppelin-compatible sorted siblings) ──
+    function _verify(bytes32[] calldata proof, bytes32 root, bytes32 leaf)
+        private
+        pure
+        returns (bool)
+    {
+        bytes32 computed = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 sibling = proof[i];
+            if (computed < sibling) {
+                computed = keccak256(abi.encodePacked(computed, sibling));
+            } else {
+                computed = keccak256(abi.encodePacked(sibling, computed));
+            }
+        }
+        return computed == root;
+    }
+}

--- a/script/DeployMerkleAirdrop.s.sol
+++ b/script/DeployMerkleAirdrop.s.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+import "forge-std/Script.sol";
+import "../contracts/MerkleAirdrop.sol";
+
+/// @title DeployMerkleAirdrop
+/// @notice Deploys a single-phase MerkleAirdrop instance.
+/// @dev One MerkleAirdrop per airdrop phase. Phase 1 (Testnet Heroes) gets
+///      its own deploy with the Phase 1 merkle root + 90-day deadline +
+///      sweep-back to Strategic Reserve + ownership to SentrixSafe.
+///
+///      Required env vars:
+///        MERKLE_ROOT          — bytes32 root of the airdrop tree
+///        CLAIM_DEADLINE       — uint256 unix timestamp claims close
+///        SWEEP_RECIPIENT      — address that receives unclaimed (Strategic Reserve EOA)
+///        OWNER                — address that calls sweep() (SentrixSafe contract)
+///        DEPLOYER_PRIVATE_KEY — private key for deploy (read off-repo)
+///
+///      Pre-fund step is SEPARATE — after deploy, transfer the phase total
+///      from Strategic Reserve to the contract via SentrixSafe execTransaction.
+///      That gives a clean two-step audit trail:
+///        1. Contract deployed (this script)
+///        2. Strategic Reserve → contract pre-fund tx (manual via Safe)
+contract DeployMerkleAirdrop is Script {
+    function run() external {
+        bytes32 root = vm.envBytes32("MERKLE_ROOT");
+        uint256 deadline = vm.envUint("CLAIM_DEADLINE");
+        address sweep = vm.envAddress("SWEEP_RECIPIENT");
+        address owner = vm.envAddress("OWNER");
+        uint256 pk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        // Sanity logs (visible in deploy output, not on-chain)
+        console.log("Merkle root:", vm.toString(root));
+        console.log("Claim deadline (unix):", deadline);
+        console.log("Sweep recipient:", sweep);
+        console.log("Owner (sweep caller):", owner);
+
+        vm.startBroadcast(pk);
+        MerkleAirdrop airdrop = new MerkleAirdrop(root, deadline, sweep, owner);
+        vm.stopBroadcast();
+
+        console.log("MerkleAirdrop deployed at:", address(airdrop));
+        console.log("");
+        console.log("NEXT STEPS:");
+        console.log("1. Verify deployment on scan.sentrixchain.com");
+        console.log("2. Pre-fund via SentrixSafe execTransaction:");
+        console.log("   - to = MerkleAirdrop address");
+        console.log("   - value = total claim amount (phase allocation in wei)");
+        console.log("   - data = 0x (empty calldata, hits receive())");
+        console.log("3. Publish merkle leaf list for recipients to verify inclusion");
+        console.log("4. Open claim portal at faucet.sentrixchain.com/airdrop");
+    }
+}

--- a/script/GenerateMerkleTree.js
+++ b/script/GenerateMerkleTree.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * GenerateMerkleTree.js — off-chain merkle tree builder for MerkleAirdrop deploys.
+ *
+ * Input:  recipients.json — array of {address, amount} pairs (amount in wei string)
+ * Output: merkle-tree.json — root + per-recipient proof + total amount
+ *
+ * Leaf format (matches MerkleAirdrop.sol _verify):
+ *   keccak256(abi.encodePacked(address, uint256))
+ *
+ * Sibling-pair hashing (sorted siblings, OpenZeppelin convention):
+ *   if (a < b) keccak256(a || b) else keccak256(b || a)
+ *
+ * Unbalanced trees: lone leaf at a level carries up unchanged (NOT padded).
+ * This matches the test contract MerkleAirdrop.t.sol convention.
+ *
+ * Usage:
+ *   node script/GenerateMerkleTree.js path/to/recipients.json
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { keccak256 } = require("ethereum-cryptography/keccak");
+const { hexToBytes, bytesToHex } = require("ethereum-cryptography/utils");
+
+function leafFor(addr, amountWei) {
+  // abi.encodePacked(address, uint256) = 20 bytes addr + 32 bytes amount
+  const addrBytes = hexToBytes(addr.toLowerCase().replace(/^0x/, ""));
+  if (addrBytes.length !== 20) {
+    throw new Error(`bad address: ${addr}`);
+  }
+  const amountHex = BigInt(amountWei).toString(16).padStart(64, "0");
+  const amountBytes = hexToBytes(amountHex);
+  const packed = new Uint8Array(52);
+  packed.set(addrBytes, 0);
+  packed.set(amountBytes, 20);
+  return keccak256(packed);
+}
+
+function hashPair(a, b) {
+  // Sorted siblings: smaller first. Compare as big-endian.
+  const aHex = bytesToHex(a);
+  const bHex = bytesToHex(b);
+  const ordered =
+    aHex < bHex ? new Uint8Array([...a, ...b]) : new Uint8Array([...b, ...a]);
+  return keccak256(ordered);
+}
+
+function buildTree(leaves) {
+  if (leaves.length === 0) throw new Error("no leaves");
+  // Build levels bottom-up. Layer 0 = leaves. Each next level pairs siblings;
+  // an odd lone node at a level passes through unchanged.
+  const levels = [leaves];
+  let current = leaves;
+  while (current.length > 1) {
+    const next = [];
+    for (let i = 0; i < current.length; i += 2) {
+      if (i + 1 < current.length) {
+        next.push(hashPair(current[i], current[i + 1]));
+      } else {
+        // Lone leaf carries up — matches MerkleAirdrop.t.sol pattern
+        next.push(current[i]);
+      }
+    }
+    levels.push(next);
+    current = next;
+  }
+  return levels;
+}
+
+function proofFor(levels, leafIndex) {
+  const proof = [];
+  let idx = leafIndex;
+  for (let level = 0; level < levels.length - 1; level++) {
+    const layer = levels[level];
+    let siblingIdx;
+    if (idx % 2 === 0) {
+      siblingIdx = idx + 1;
+    } else {
+      siblingIdx = idx - 1;
+    }
+    if (siblingIdx < layer.length) {
+      proof.push(bytesToHex(layer[siblingIdx]));
+    }
+    // If sibling missing (lone-leaf carry-up), no proof entry added at this level
+    idx = Math.floor(idx / 2);
+  }
+  return proof;
+}
+
+function main() {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error("Usage: node GenerateMerkleTree.js <recipients.json>");
+    console.error("");
+    console.error("recipients.json format:");
+    console.error('  [{"address": "0x...", "amount": "1000000000000000000"}, ...]');
+    process.exit(2);
+  }
+
+  const recipients = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  if (!Array.isArray(recipients)) {
+    throw new Error("recipients.json must be an array");
+  }
+
+  // Sort recipients by address (canonical order — makes the root stable across
+  // re-runs even if input order changes)
+  recipients.sort((a, b) => a.address.toLowerCase().localeCompare(b.address.toLowerCase()));
+
+  const leaves = recipients.map((r) => leafFor(r.address, r.amount));
+  const levels = buildTree(leaves);
+  const root = levels[levels.length - 1][0];
+
+  const totalAmount = recipients.reduce(
+    (sum, r) => sum + BigInt(r.amount),
+    0n,
+  );
+
+  const output = {
+    merkleRoot: "0x" + bytesToHex(root),
+    totalAmount: totalAmount.toString(),
+    recipientCount: recipients.length,
+    recipients: recipients.map((r, i) => ({
+      address: r.address,
+      amount: r.amount,
+      proof: proofFor(levels, i).map((h) => "0x" + h),
+    })),
+  };
+
+  const outputPath = path.join(
+    path.dirname(inputPath),
+    "merkle-tree.json",
+  );
+  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+
+  console.log(`Merkle root: 0x${bytesToHex(root)}`);
+  console.log(`Total amount: ${totalAmount} wei (${Number(totalAmount) / 1e18} SRX)`);
+  console.log(`Recipients: ${recipients.length}`);
+  console.log(`Output: ${outputPath}`);
+}
+
+main();

--- a/test/MerkleAirdrop.t.sol
+++ b/test/MerkleAirdrop.t.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/MerkleAirdrop.sol";
+
+contract MerkleAirdropTest is Test {
+    MerkleAirdrop airdrop;
+
+    address constant ALICE = address(0xA11CE);
+    address constant BOB = address(0xB0B0);
+    address constant CAROL = address(0xCAA01);
+    address constant DAN = address(0xDAD); // not in tree
+
+    address constant OWNER = address(0x0FF1CE); // SentrixSafe stand-in
+    address constant SWEEP_TARGET = address(0x5EED); // Strategic Reserve stand-in
+
+    uint256 constant ALICE_AMT = 100 ether;
+    uint256 constant BOB_AMT = 200 ether;
+    uint256 constant CAROL_AMT = 300 ether;
+    uint256 constant TOTAL = ALICE_AMT + BOB_AMT + CAROL_AMT;
+
+    bytes32 constant ALICE_LEAF = keccak256(abi.encodePacked(ALICE, ALICE_AMT));
+    bytes32 constant BOB_LEAF = keccak256(abi.encodePacked(BOB, BOB_AMT));
+    bytes32 constant CAROL_LEAF = keccak256(abi.encodePacked(CAROL, CAROL_AMT));
+
+    bytes32 root;
+    uint256 deadline;
+
+    function setUp() public {
+        // Build a 3-leaf tree (Alice, Bob, Carol) by sorting leaves and pair-hashing.
+        // Tree shape (sorted siblings):
+        //          root
+        //         /    \
+        //      H(AB)   H(C, C)  -- single-leaf branch padded with itself? No: standard
+        //                          OpenZeppelin trees pair-hash unbalanced trees by
+        //                          carrying the lone leaf up. We simulate that:
+        //          root = H_sorted(H_sorted(A, B), C)
+
+        bytes32 ab = _hashPair(ALICE_LEAF, BOB_LEAF);
+        root = _hashPair(ab, CAROL_LEAF);
+
+        deadline = block.timestamp + 90 days;
+
+        airdrop = new MerkleAirdrop(root, deadline, SWEEP_TARGET, OWNER);
+
+        // Pre-fund the contract with the total claim amount + a buffer
+        vm.deal(address(this), TOTAL + 10 ether);
+        (bool ok,) = address(airdrop).call{value: TOTAL + 10 ether}("");
+        require(ok, "fund failed");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────
+    function _hashPair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+
+    function _aliceProof() internal pure returns (bytes32[] memory) {
+        bytes32[] memory p = new bytes32[](2);
+        p[0] = BOB_LEAF; // sibling at level 0
+        p[1] = CAROL_LEAF; // sibling at level 1
+        return p;
+    }
+
+    function _bobProof() internal pure returns (bytes32[] memory) {
+        bytes32[] memory p = new bytes32[](2);
+        p[0] = ALICE_LEAF;
+        p[1] = CAROL_LEAF;
+        return p;
+    }
+
+    function _carolProof() internal pure returns (bytes32[] memory) {
+        bytes32[] memory p = new bytes32[](1);
+        p[0] = _hashPair(ALICE_LEAF, BOB_LEAF);
+        return p;
+    }
+
+    // ── Tests ────────────────────────────────────────────────
+
+    function test_constructor_setsImmutables() public view {
+        assertEq(airdrop.merkleRoot(), root);
+        assertEq(airdrop.claimDeadline(), deadline);
+        assertEq(airdrop.sweepRecipient(), SWEEP_TARGET);
+        assertEq(airdrop.owner(), OWNER);
+        assertFalse(airdrop.swept());
+        assertEq(airdrop.totalClaimed(), 0);
+    }
+
+    function test_constructor_revertsOnZeroSweepRecipient() public {
+        vm.expectRevert(MerkleAirdrop.ZeroAddress.selector);
+        new MerkleAirdrop(root, deadline, address(0), OWNER);
+    }
+
+    function test_constructor_revertsOnZeroOwner() public {
+        vm.expectRevert(MerkleAirdrop.ZeroAddress.selector);
+        new MerkleAirdrop(root, deadline, SWEEP_TARGET, address(0));
+    }
+
+    function test_claim_aliceSucceeds() public {
+        uint256 balanceBefore = ALICE.balance;
+
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+
+        assertEq(ALICE.balance, balanceBefore + ALICE_AMT);
+        assertTrue(airdrop.claimed(ALICE));
+        assertEq(airdrop.totalClaimed(), ALICE_AMT);
+    }
+
+    function test_claim_emitsEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit MerkleAirdrop.Claimed(ALICE, ALICE_AMT);
+
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+    }
+
+    function test_claim_revertsOnDoubleClaim() public {
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+
+        vm.expectRevert(MerkleAirdrop.AlreadyClaimed.selector);
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+    }
+
+    function test_claim_revertsOnInvalidAmount() public {
+        // Alice tries to claim Bob's amount with her proof
+        vm.expectRevert(MerkleAirdrop.InvalidProof.selector);
+        vm.prank(ALICE);
+        airdrop.claim(BOB_AMT, _aliceProof());
+    }
+
+    function test_claim_revertsOnNonRecipient() public {
+        // Dan tries to claim with Alice's proof
+        vm.expectRevert(MerkleAirdrop.InvalidProof.selector);
+        vm.prank(DAN);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+    }
+
+    function test_claim_revertsAfterDeadline() public {
+        vm.warp(deadline + 1);
+        vm.expectRevert(MerkleAirdrop.ClaimWindowClosed.selector);
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+    }
+
+    function test_claim_revertsAfterSweep() public {
+        // Warp past deadline + sweep
+        vm.warp(deadline + 1);
+        vm.prank(OWNER);
+        airdrop.sweep();
+
+        // Even if we warp back (impossible IRL, but tests reentrancy-style logic)
+        vm.warp(deadline - 1);
+        vm.expectRevert(MerkleAirdrop.AlreadySwept.selector);
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+    }
+
+    function test_multipleClaims_independent() public {
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+
+        vm.prank(BOB);
+        airdrop.claim(BOB_AMT, _bobProof());
+
+        vm.prank(CAROL);
+        airdrop.claim(CAROL_AMT, _carolProof());
+
+        assertEq(airdrop.totalClaimed(), TOTAL);
+        assertEq(ALICE.balance, ALICE_AMT);
+        assertEq(BOB.balance, BOB_AMT);
+        assertEq(CAROL.balance, CAROL_AMT);
+    }
+
+    function test_sweep_revertsBeforeDeadline() public {
+        vm.expectRevert(MerkleAirdrop.ClaimWindowOpen.selector);
+        vm.prank(OWNER);
+        airdrop.sweep();
+    }
+
+    function test_sweep_revertsForNonOwner() public {
+        vm.warp(deadline + 1);
+        vm.expectRevert(MerkleAirdrop.NotOwner.selector);
+        vm.prank(ALICE);
+        airdrop.sweep();
+    }
+
+    function test_sweep_succeedsAfterDeadline() public {
+        // Alice claims, Bob+Carol don't
+        vm.prank(ALICE);
+        airdrop.claim(ALICE_AMT, _aliceProof());
+
+        uint256 balanceBefore = SWEEP_TARGET.balance;
+        uint256 expectedSweep = address(airdrop).balance; // includes the buffer
+
+        vm.warp(deadline + 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit MerkleAirdrop.Swept(SWEEP_TARGET, expectedSweep);
+
+        vm.prank(OWNER);
+        airdrop.sweep();
+
+        assertEq(SWEEP_TARGET.balance, balanceBefore + expectedSweep);
+        assertTrue(airdrop.swept());
+        assertEq(address(airdrop).balance, 0);
+    }
+
+    function test_sweep_cannotBeCalledTwice() public {
+        vm.warp(deadline + 1);
+        vm.prank(OWNER);
+        airdrop.sweep();
+
+        vm.expectRevert(MerkleAirdrop.AlreadySwept.selector);
+        vm.prank(OWNER);
+        airdrop.sweep();
+    }
+
+    function test_isEligible_view() public view {
+        assertTrue(airdrop.isEligible(ALICE, ALICE_AMT, _aliceProof()));
+        assertTrue(airdrop.isEligible(BOB, BOB_AMT, _bobProof()));
+        assertTrue(airdrop.isEligible(CAROL, CAROL_AMT, _carolProof()));
+        assertFalse(airdrop.isEligible(DAN, ALICE_AMT, _aliceProof()));
+        assertFalse(airdrop.isEligible(ALICE, BOB_AMT, _aliceProof()));
+    }
+
+    function test_receive_anyoneCanFund() public {
+        vm.deal(BOB, 1 ether);
+        uint256 before = address(airdrop).balance;
+        vm.prank(BOB);
+        (bool ok,) = address(airdrop).call{value: 1 ether}("");
+        assertTrue(ok);
+        assertEq(address(airdrop).balance, before + 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
5th canonical contract: \`MerkleAirdrop.sol\`. One instance per airdrop phase; pre-funded from Strategic Reserve, recipients claim via merkle proof, owner sweeps unclaimed balance back after deadline.

### Files
- \`contracts/MerkleAirdrop.sol\` — immutable, no proxy, no admin keys post-deploy except owner-callable \`sweep()\`
- \`test/MerkleAirdrop.t.sol\` — 17/17 tests passing
- \`script/DeployMerkleAirdrop.s.sol\` — Foundry deploy script
- \`script/GenerateMerkleTree.js\` — off-chain tree builder for recipients.json

### Design highlights
- Sorted-siblings merkle verification (OpenZeppelin convention)
- Custom errors (gas + clarity)
- Pre-fund via \`receive()\` — anyone can fund, typical flow is Strategic Reserve via SentrixSafe execTransaction
- Sweep destination = Strategic Reserve (returns unclaimed, doesn't burn — preserves supply curve)

## Test plan
- [x] forge test --match-contract MerkleAirdropTest → 17/17 passing
- [x] forge build clean
- [x] Full test suite still passes (47/47)
- [ ] Deploy to testnet for Phase 1 dry-run (separate task)