### PR TITLE
fix(coinblast): clamp srxRaised + block shadow-pair graduation (audit H4+H5)

### DIFF
--- a/contracts/CoinBlastCurve.sol
+++ b/contracts/CoinBlastCurve.sol
@@ -3,6 +3,18 @@ pragma solidity 0.8.24;
 
 import {FactoryToken} from "./TokenFactory.sol";
 
+/// Minimal interface for the Sentrix V2 router/factory at graduation time.
+/// We use these only for read-only checks (audit H5 shadow-pair guard);
+/// the actual addLiquiditySRX call is still done via low-level call so the
+/// router ABI evolves independently.
+interface IRouterMinimal {
+    function factory() external view returns (address);
+}
+
+interface IFactoryMinimal {
+    function getPair(address tokenA, address tokenB) external view returns (address);
+}
+
 /// @title CoinBlastCurve
 /// @author Sentrix Labs
 /// @notice On-chain linear bonding curve for the CoinBlast launchpad. One
@@ -263,7 +275,16 @@ contract CoinBlastCurve {
 
         require(token.transferFrom(msg.sender, address(this), tokensIn), "CoinBlast: TOKEN_TRANSFER_FROM");
         tokensSold -= tokensIn;
-        srxRaised -= (srxNet + fee);
+
+        // Audit H4 (HIGH, 2026-05-07): srxRaised is a derived figure that
+        // can drift from address(this).balance because quoteBuy/quoteSell fee
+        // math truncates sub-wei lossage on each trade. The pre-fix line was
+        // `srxRaised -= (srxNet + fee)` which could underflow → revert →
+        // sells permanently locked until graduation threshold met. Clamp the
+        // debit at zero so the underflow is impossible; address(this).balance
+        // remains the true source of truth for outflows below.
+        uint256 debit = srxNet + fee;
+        srxRaised = srxRaised >= debit ? srxRaised - debit : 0;
 
         if (fee > 0) _safeSendSRX(feeRecipient, fee);
         _safeSendSRX(msg.sender, srxNet);
@@ -279,6 +300,21 @@ contract CoinBlastCurve {
     ///         Sentrix V2 pool and burns the LP forever.
     function graduate() external active nonReentrant {
         if (srxRaised < graduationSrxThreshold) revert NotGraduatable();
+
+        // Audit H5 (HIGH, 2026-05-07): graduate() was unauthenticated and
+        // someone could front-run by pre-creating a (token, wsrx) pair on
+        // the V2 factory with skewed reserves before this call. addLiquidity
+        // would then mint LP at a manipulated ratio, leaking value to whoever
+        // arbitraged the first post-graduation swap. Guard: read the pinned
+        // router's factory, ask if a pair already exists for our (token, wsrx),
+        // and revert if so. This forces the curve to be the SOLE creator of
+        // its launch pair.
+        address factoryAddr = IRouterMinimal(router).factory();
+        require(
+            IFactoryMinimal(factoryAddr).getPair(address(token), wsrx) == address(0),
+            "CoinBlast: PAIR_EXISTS"
+        );
+
         graduated = true;
 
         uint256 tokenLiquidity = token.balanceOf(address(this));
@@ -312,16 +348,9 @@ contract CoinBlastCurve {
         // need the LP amount for the event log.
         (,, uint256 lpBurned) = abi.decode(ret, (uint256, uint256, uint256));
 
-        // Compute the deterministic pair address by reading the factory off the
-        // router. Done after the router call so we know the pair definitely
-        // exists.
-        (bool fOk, bytes memory fRet) = router.staticcall(abi.encodeWithSignature("factory()"));
-        require(fOk, "CoinBlast: FACTORY_LOOKUP");
-        address factoryAddr = abi.decode(fRet, (address));
-        (bool pOk, bytes memory pRet) =
-            factoryAddr.staticcall(abi.encodeWithSignature("getPair(address,address)", address(token), wsrx));
-        require(pOk, "CoinBlast: PAIR_LOOKUP");
-        address pair = abi.decode(pRet, (address));
+        // Compute the pair address by re-using the factory we already
+        // looked up at the H5 guard above (no need for two factory() calls).
+        address pair = IFactoryMinimal(factoryAddr).getPair(address(token), wsrx);
 
         emit Graduated(pair, srxLiquidity, tokenLiquidity, lpBurned);
     }

--- a/test/CoinBlastCurve.t.sol
+++ b/test/CoinBlastCurve.t.sol
@@ -42,6 +42,11 @@ contract MockRouter {
         amountSRX = msg.value;
         // Pretend LP minted = sqrt-ish; we don't need it to be exact.
         liquidity = amountToken < amountSRX ? amountToken : amountSRX;
+        // Mimic real router behaviour: createPair-or-fetch on the factory
+        // such that subsequent getPair() returns the new pair address. This
+        // keeps the test's post-graduation pair lookup working even after
+        // the H5 guard rejects pre-existing pairs.
+        MockFactory(mockFactory).setPair(token, mockWsrx, address(uint160(uint256(keccak256(abi.encode(token, mockWsrx))))));
     }
 }
 
@@ -102,8 +107,11 @@ contract CoinBlastCurveTest is Test {
         });
         curve = new CoinBlastCurve(p);
 
-        // Now register the pair address (after curve constructor created the token)
-        factory.setPair(address(curve.token()), wsrx, address(0xBeef));
+        // Audit H5: do NOT pre-register the pair. The H5 guard requires
+        // factory.getPair(token, wsrx) == address(0) at graduate-time so the
+        // curve is the SOLE creator of its launch pair. The MockRouter's
+        // addLiquiditySRX now sets the pair as part of "creating" liquidity,
+        // mimicking the real factory's createPair-or-fetch semantics.
 
         vm.deal(alice, 1000 ether);
         vm.deal(bob, 1000 ether);
@@ -247,7 +255,8 @@ contract CoinBlastCurveTest is Test {
         p.feeRecipient = address(attacker);
         CoinBlastCurve victim = new CoinBlastCurve(p);
         attacker.setCurve(victim);
-        factory.setPair(address(victim.token()), wsrx, address(0xC0DE));
+        // Audit H5: don't pre-register the pair; only addLiquiditySRX (in the
+        // mock router) sets it now.
 
         vm.deal(address(attacker), 100 ether);
         vm.expectRevert(CoinBlastCurve.TransferFailed.selector);
@@ -315,6 +324,47 @@ contract CoinBlastCurveTest is Test {
         vm.prank(alice);
         (bool ok,) = address(curve).call{value: 1 ether}("");
         assertFalse(ok);
+    }
+
+    // ── Audit H5: shadow-pair griefing block ────────────────────────
+
+    function test_graduate_reverts_if_shadow_pair_exists() public {
+        // Buy past threshold first (enough to push srxRaised past GRAD_THRESHOLD)
+        vm.deal(alice, 100000 ether);
+        vm.prank(alice);
+        curve.buy{value: 100000 ether}(0);
+        // Sanity: threshold met
+        assertGe(curve.srxRaised(), GRAD_THRESHOLD);
+
+        // Griefer pre-registers the pair (mimics the front-run on the
+        // canonical V2 factory).
+        factory.setPair(address(curve.token()), wsrx, address(0xBADCAFE));
+
+        // graduate() must now refuse — the curve isn't the sole pair creator.
+        vm.expectRevert(bytes("CoinBlast: PAIR_EXISTS"));
+        curve.graduate();
+    }
+
+    // ── Audit H4: srxRaised underflow guard ─────────────────────────
+
+    function test_sell_does_not_underflow_with_zero_raised() public {
+        // Audit H4: buy then sell back should never underflow on srxRaised.
+        // Pre-fix: `srxRaised -= (srxNet + fee)` could underflow if rounding
+        // drift accumulated. Post-fix: clamped subtraction keeps srxRaised
+        // ≥ 0; the actual native outflow is bounded by address(this).balance.
+        vm.deal(alice, 100 ether);
+        vm.prank(alice);
+        curve.buy{value: 1 ether}(0);
+
+        uint256 aliceTokens = curve.token().balanceOf(alice);
+        assertGt(aliceTokens, 0, "buy delivered no tokens");
+
+        vm.startPrank(alice);
+        curve.token().approve(address(curve), aliceTokens);
+        // Sell — must not revert with arithmetic underflow.
+        curve.sell(aliceTokens, 0);
+        vm.stopPrank();
+        // No revert + final srxRaised within sane bounds is the H4 property.
     }
 }
 


### PR DESCRIPTION
Audit 2026-05-07 H4+H5 (HIGH × 2):

**H4** — sell() `srxRaised -= (srxNet + fee)` could underflow → sells locked. Now clamped via ternary; address(this).balance is the truth.

**H5** — graduate() didn't check for pre-existing pair, allowing shadow-pair griefing. Now reverts with `PAIR_EXISTS` if factory.getPair returns non-zero.

22/22 tests passing including 2 new H4+H5-specific cases. Mock router updated to mimic real createPair-on-addLiquidity behaviour.

Note: deployed CoinBlast curves on mainnet are immutable — applies only to future curve deployments.