### PR TITLE
polish: FactoryToken zero-owner guard + Approval emit on spend

### DIFF
--- a/contracts/TokenFactory.sol
+++ b/contracts/TokenFactory.sol
@@ -53,6 +53,10 @@ contract FactoryToken {
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
     constructor(string memory _name, string memory _symbol, uint256 _initialSupply, address _owner) {
+        // Defense-in-depth: TokenFactory always passes msg.sender so this
+        // can't trigger via the factory path, but a direct deploy with
+        // _owner=0 would trap the entire supply in the zero address. Reject.
+        require(_owner != address(0), "FactoryToken: OWNER_ZERO");
         name = _name;
         symbol = _symbol;
         totalSupply = _initialSupply;
@@ -75,7 +79,12 @@ contract FactoryToken {
             uint256 allowed = allowance[from][msg.sender];
             if (allowed != type(uint256).max) {
                 require(allowed >= amount, "FactoryToken: insufficient allowance");
-                allowance[from][msg.sender] = allowed - amount;
+                uint256 remaining = allowed - amount;
+                allowance[from][msg.sender] = remaining;
+                // OZ-style: emit Approval on each spend so indexers tracking
+                // allowance state changes (e.g. CoinGecko / explorer ABI
+                // decoders) see the new value without re-reading storage.
+                emit Approval(from, msg.sender, remaining);
             }
         }
         return _transfer(from, to, amount);

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -100,4 +100,28 @@ contract FactoryTest is Test {
         vm.expectRevert(bytes("FactoryToken: TO_ZERO"));
         t.transfer(address(0), 1);
     }
+
+    function test_factory_token_direct_deploy_to_zero_owner_reverts() public {
+        // TokenFactory always passes msg.sender, so this is reachable only
+        // via a direct `new FactoryToken(..., address(0))`. Defense-in-depth.
+        vm.expectRevert(bytes("FactoryToken: OWNER_ZERO"));
+        new FactoryToken("X", "X", 1 ether, address(0));
+    }
+
+    function test_factory_token_transferFrom_emits_approval_on_spend() public {
+        vm.prank(alice);
+        address token = factory.deployToken("Test", "TST", 1000 ether);
+        FactoryToken t = FactoryToken(token);
+
+        vm.prank(alice);
+        t.approve(bob, 500 ether);
+
+        // OZ-style: each spend emits Approval with the remaining allowance.
+        vm.prank(bob);
+        vm.expectEmit(true, true, false, true, address(t));
+        emit FactoryToken.Approval(alice, bob, 400 ether);
+        t.transferFrom(alice, bob, 100 ether);
+
+        assertEq(t.allowance(alice, bob), 400 ether);
+    }
 }


### PR DESCRIPTION
## Summary

Two defense-in-depth polish items on `FactoryToken` after a review pass — keeping the existing custom ERC20 (no OpenZeppelin swap).

### 1. Constructor zero-owner guard

\`\`\`solidity
require(_owner != address(0), "FactoryToken: OWNER_ZERO");
\`\`\`

\`TokenFactory.deployToken\` always passes \`msg.sender\` so the factory path can't trip this, but a direct \`new FactoryToken(..., address(0))\` would mint the entire supply to the zero address (trapped forever). Loud failure at deploy time is the right behaviour.

### 2. \`Approval\` emit on allowance spend

\`\`\`solidity
emit Approval(from, msg.sender, remaining);
\`\`\`

OpenZeppelin v5 emits \`Approval\` on each \`transferFrom\` spend so external indexers (CoinGecko / block explorers / ABI decoders) can track allowance state changes via logs without re-reading storage. Matches industry convention. Zero functional change.

## Test plan

- 2 new tests in \`test/Factory.t.sol\`: \`test_factory_token_direct_deploy_to_zero_owner_reverts\` + \`test_factory_token_transferFrom_emits_approval_on_spend\`
- Full suite: 103/103 green