### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
 
@@ -54,7 +54,7 @@ jobs:
       - name: install slither
         run: pip install slither-analyzer
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,9 +17,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install slither-analyzer
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
       - run: forge install foundry-rs/forge-std


### PR DESCRIPTION
Round-2 audit fix. Pins all unpinned third-party action `uses:` to current commit SHAs (immutable). Tag annotations preserved as trailing comments for future bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI, CodeQL, release, and security workflows to pin third-party GitHub Actions to fixed revisions instead of floating tags, improving automation reproducibility and build consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->