### PR TITLE
ci: add link-check workflow (lychee)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,39 @@
+name: link-check
+
+# Lychee scans every markdown link in this repo so dead URLs surface
+# before users hit them. Runs on PR + push to main + a weekly cron so
+# rot is caught even between releases.
+#
+# Non-blocking on findings (matches the gitleaks workflow's policy) —
+# branch protection gates that the scan ran; results appear in the
+# workflow summary so an operator can decide whether to fix or accept.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'  # Mondays 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    name: lychee (link check)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 8
+            --exclude-mail
+            --accept 200,206,403,429
+            '**/*.md'
+          fail: false


### PR DESCRIPTION
Same pattern as awesome-sentrix's link-check workflow. Lychee scans every markdown link on PR + push to main + a weekly Monday 03:00 UTC cron. Non-blocking, mirroring gitleaks policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated documentation link validation. Markdown files are now automatically scanned for broken URLs on pull requests, main branch updates, and weekly schedules. This proactive validation helps maintain documentation quality by identifying invalid references and ensuring all external links remain accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->