### PR TITLE
fix(audit): pull-pattern fees + delegatecall-value revert + sell drift clamp

### DIFF
--- a/contracts/CoinBlastCurve.sol
+++ b/contracts/CoinBlastCurve.sol
@@ -82,10 +82,23 @@ contract CoinBlastCurve {
     /// @dev Reentrancy lock — initialised to 1 so the first acquire is cheap.
     uint256 private _locked = 1;
 
+    /// @notice Audit M1 (MEDIUM, 2026-05-13): pull-pattern fee escrow.
+    ///         Pre-fix every buy/sell forwarded the fee directly to
+    ///         `feeRecipient` via .call{value:}. If that recipient ever
+    ///         reverted on receive (contract upgrade, SELFDESTRUCT-then-
+    ///         recreate, or future bug) every trade on this curve would
+    ///         revert forever — per-curve DoS, all trader funds locked.
+    ///         Now we accrue into pendingFees[recipient] and the recipient
+    ///         pulls via claimFees(). Buy/sell paths can no longer be
+    ///         bricked by fee-recipient bytecode.
+    mapping(address => uint256) public pendingFees;
+
     // ── Events ────────────────────────────────────────────────────────
     event Buy(address indexed buyer, uint256 srxIn, uint256 fee, uint256 tokensOut);
     event Sell(address indexed seller, uint256 tokensIn, uint256 fee, uint256 srxOut);
     event Graduated(address indexed pair, uint256 srxLiquidity, uint256 tokenLiquidity, uint256 lpBurned);
+    event FeeAccrued(address indexed recipient, uint256 amount);
+    event FeesClaimed(address indexed recipient, uint256 amount);
 
     // ── Errors ────────────────────────────────────────────────────────
     error AlreadyGraduated();
@@ -97,6 +110,7 @@ contract CoinBlastCurve {
     error Reentrancy();
     error FeeTooHigh();
     error InvalidParams();
+    error NoFeesToClaim();
 
     modifier nonReentrant() {
         if (_locked != 1) revert Reentrancy();
@@ -251,8 +265,8 @@ contract CoinBlastCurve {
         tokensSold += tokensOut;
         srxRaised += (grossPaid - fee);
 
-        // Forward fee to recipient; refund any dust to buyer.
-        if (fee > 0) _safeSendSRX(feeRecipient, fee);
+        // Audit M1: accrue fee for pull (was direct .call); refund dust to buyer.
+        _accrueFee(feeRecipient, fee);
         uint256 refund = msg.value - grossPaid;
         if (refund > 0) _safeSendSRX(msg.sender, refund);
 
@@ -286,11 +300,44 @@ contract CoinBlastCurve {
         uint256 debit = srxNet + fee;
         srxRaised = srxRaised >= debit ? srxRaised - debit : 0;
 
-        if (fee > 0) _safeSendSRX(feeRecipient, fee);
+        // Audit M2 (MEDIUM, 2026-05-13): H4-extended. H4 clamped srxRaised;
+        // this clamps the actual transfer to balance to prevent griefing-DoS
+        // on rounding drift. Adversarial buy/sell sequences can leave
+        // address(this).balance < srxNet+fee by ≤1 wei per trade. Without
+        // this clamp the outer _safeSendSRX would revert and lock sells.
+        // Bound: per-trade drift ≤1 wei, so deficit ≤ historical_trades wei.
+        uint256 available = address(this).balance;
+        if (srxNet + fee > available) {
+            uint256 deficit = srxNet + fee - available;
+            if (srxNet >= deficit) { srxNet -= deficit; }
+            else { fee -= (deficit - srxNet); srxNet = 0; }
+        }
+
+        // Audit M1: accrue fee for pull (was direct .call).
+        _accrueFee(feeRecipient, fee);
         _safeSendSRX(msg.sender, srxNet);
 
         emit Sell(msg.sender, tokensIn, fee, srxNet);
         srxOut = srxNet;
+    }
+
+    // ── Fee escrow (audit M1) ─────────────────────────────────────────
+
+    /// @notice Pull-pattern: fee recipient claims accrued SRX. Anyone can
+    ///         claim their own balance; we don't allow third-party claims so
+    ///         a buggy recipient can't front-run their own withdrawal.
+    function claimFees() external nonReentrant {
+        uint256 amount = pendingFees[msg.sender];
+        if (amount == 0) revert NoFeesToClaim();
+        pendingFees[msg.sender] = 0;
+        _safeSendSRX(msg.sender, amount);
+        emit FeesClaimed(msg.sender, amount);
+    }
+
+    function _accrueFee(address recipient, uint256 amount) internal {
+        if (amount == 0) return;
+        pendingFees[recipient] += amount;
+        emit FeeAccrued(recipient, amount);
     }
 
     // ── Graduation ────────────────────────────────────────────────────
@@ -331,15 +378,23 @@ contract CoinBlastCurve {
 
         // Approve router to pull tokens, then add liquidity. LP receipt is
         // sent to address(0) → permanently locked.
+        //
+        // Audit M3 (MEDIUM, 2026-05-13): the addLiquiditySRX signature is
+        //   (token, amountTokenDesired, amountTokenMin, amountSRXMin, to, deadline)
+        // — pre-fix we passed `tokenLiquidity` as both desired AND min, and
+        // `srxLiquidity` as the SRX min. The H5 guard already proves we are
+        // the SOLE pair creator (factory.getPair == 0), so no prior reserves
+        // exist to manipulate the deposit ratio. Pass `1` for both mins —
+        // any non-zero accepted, no slippage exposure.
         require(token.approve(router, tokenLiquidity), "CoinBlast: APPROVE");
         (bool ok, bytes memory ret) = router.call{value: srxLiquidity}(
             abi.encodeWithSignature(
                 "addLiquiditySRX(address,uint256,uint256,uint256,address,uint256)",
                 address(token),
-                tokenLiquidity,
-                tokenLiquidity, // accept any positive token amount (we control supply)
-                srxLiquidity,    // accept any positive SRX amount (we control raise)
-                address(0xdEaD),  // LP receipt destination — burnt forever
+                tokenLiquidity, // amountTokenDesired
+                uint256(1),     // amountTokenMin (sole LP, no slippage exposure)
+                uint256(1),     // amountSRXMin
+                address(0xdEaD), // LP receipt destination — burnt forever
                 block.timestamp + 1 hours
             )
         );

--- a/contracts/MerkleAirdrop.sol
+++ b/contracts/MerkleAirdrop.sol
@@ -75,6 +75,15 @@ contract MerkleAirdrop {
     /// @notice Claim airdrop allocation by submitting a merkle proof.
     /// @param amount The allocated amount (in wei) for the calling address.
     /// @param proof Merkle proof showing `(msg.sender, amount)` is in the tree.
+    /// @dev Audit L-MA (LOW, 2026-05-13): single-leaf-per-address precondition.
+    ///      The `claimed[msg.sender]` flag is keyed by address, NOT by leaf
+    ///      hash — so trees containing multiple leaves for the same address
+    ///      (e.g. one per reward tier) will silently allow only the first
+    ///      claim; later tiers are unclaimable. If multi-tier rewards are
+    ///      needed, either deploy one MerkleAirdrop per tier OR re-key the
+    ///      mapping by leaf-hash and adopt a `(address, amount, tier)` leaf
+    ///      encoding. The current Phase 1 (Testnet Heroes) uses one leaf per
+    ///      address so this is the documented contract.
     function claim(uint256 amount, bytes32[] calldata proof) external {
         if (block.timestamp > claimDeadline) revert ClaimWindowClosed();
         if (claimed[msg.sender]) revert AlreadyClaimed();

--- a/contracts/Multicall3.sol
+++ b/contracts/Multicall3.sol
@@ -106,10 +106,12 @@ contract Multicall3 {
     }
 
     function blockAndAggregate(Call[] calldata calls) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        require(msg.value == 0, "Multicall3: use aggregate3Value to send native");
         (blockNumber, blockHash, returnData) = tryBlockAndAggregate(calls);
     }
 
     function tryBlockAndAggregate(Call[] calldata calls) public payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        require(msg.value == 0, "Multicall3: use aggregate3Value to send native");
         blockNumber = block.number;
         blockHash = blockhash(block.number);
         uint256 length = calls.length;

--- a/contracts/Multicall3.sol
+++ b/contracts/Multicall3.sol
@@ -6,8 +6,16 @@ pragma solidity 0.8.24;
 /// @notice Aggregate read/write contract calls into a single tx.
 /// @dev Mirror of github.com/mds1/multicall (canonical address
 ///      0xcA11bde05977b3631167028862bE2a173976CA11 across most chains).
-///      Reproduced here verbatim to keep the canonical-contracts repo
-///      self-contained. License preserved (MIT - owner: Matt Solomon).
+///      Reproduced here to keep the canonical-contracts repo self-contained.
+///      License preserved (MIT - owner: Matt Solomon).
+///
+///      Audit L-MC (LOW, 2026-05-13): we diverge from upstream by guarding
+///      `aggregate()` and `aggregate3()` with `require(msg.value == 0)`.
+///      Upstream marks both `payable` even though the per-call paths don't
+///      forward value, so any SRX sent in by mistake is stranded inside the
+///      Multicall (it has no withdraw path). The Value variant is the only
+///      legitimate native-bearing entry point. Note: this means the deployed
+///      bytecode no longer matches the canonical 0xcA11... address.
 contract Multicall3 {
     struct Call {
         address target;
@@ -34,6 +42,7 @@ contract Multicall3 {
 
     /// @notice Backwards-compatible aggregate (reverts on any failure).
     function aggregate(Call[] calldata calls) external payable returns (uint256 blockNumber, bytes[] memory returnData) {
+        require(msg.value == 0, "Multicall3: use aggregate3Value to send native");
         blockNumber = block.number;
         uint256 length = calls.length;
         returnData = new bytes[](length);
@@ -49,6 +58,7 @@ contract Multicall3 {
 
     /// @notice Aggregate calls; per-call failure mode controllable.
     function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData) {
+        require(msg.value == 0, "Multicall3: use aggregate3Value to send native");
         uint256 length = calls.length;
         returnData = new Result[](length);
         Call3 calldata calli;

--- a/contracts/SentrixSafe.sol
+++ b/contracts/SentrixSafe.sol
@@ -49,6 +49,15 @@ contract SentrixSafe {
     event RemovedOwner(address indexed owner);
     event ChangedThreshold(uint256 threshold);
 
+    // ── Errors (audit 2026-05-13) ────────────────────────────
+    /// @dev Audit M-Safe (MEDIUM): owners sign over `value` but DELEGATECALL
+    ///      ignores msg.value at the opcode level (the executing code runs in
+    ///      this Safe's context with this Safe's balance). Pre-fix the value
+    ///      was silently dropped, so an N-of-M quorum could approve a
+    ///      "send 1 ETH via delegatecall to X" payload, see ExecutionSuccess,
+    ///      and never realise the transfer was a no-op. Reject at exec.
+    error DelegateCallWithValue();
+
     // ── Constructor ──────────────────────────────────────────
     constructor(address[] memory _owners, uint256 _threshold) {
         require(_owners.length > 0, "Safe: no owners");
@@ -115,6 +124,12 @@ contract SentrixSafe {
         checkSignatures(txHash, signatures);
         nonce++;
 
+        // Audit M-Safe (MEDIUM, 2026-05-13): reject the silent-value-drop
+        // class. Owners sign over `value` but DELEGATECALL doesn't transfer.
+        // If the intent was "transfer + delegatecall combined", the caller
+        // should split into two ops (send via call, then delegatecall).
+        if (operation == 1 && value != 0) revert DelegateCallWithValue();
+
         if (operation == 1) {
             // Audit C1 (CRITICAL, 2026-05-07): pre-fix this assembly used
             // `data.offset` (a CALLDATA offset) directly as the DELEGATECALL
@@ -180,6 +195,13 @@ contract SentrixSafe {
             s := calldataload(add(sigPtr, 32))
             v := byte(0, calldataload(add(sigPtr, 64)))
         }
+        // Audit L-Safe (LOW, 2026-05-13): EIP-2 signature malleability.
+        // ecrecover accepts both s and (n-s) as valid for the same message.
+        // Without bounding s, the same approval can be re-encoded into a
+        // distinct 65-byte blob; harmless here (nonce blocks replay) but
+        // hygiene. v must be 27/28; pre-EIP-155 chain-id encoding rejected.
+        require(uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, "Safe: invalid s");
+        require(v == 27 || v == 28, "Safe: invalid v");
         return ecrecover(dataHash, v, r, s);
     }
 
@@ -205,6 +227,11 @@ contract SentrixSafe {
     receive() external payable {}
 
     // ── Owner management (self-call only via execTransaction) ─
+    /// @notice Add a new owner and optionally re-set the threshold.
+    /// @dev Audit L-Safe (LOW, 2026-05-13): must be invoked via
+    ///      execTransaction with operation=Operation.Call (i.e. operation=0);
+    ///      delegatecall self-invocation will fail because msg.sender becomes
+    ///      the owner EOA, not address(this), and the self-call guard rejects.
     function addOwner(address owner, uint256 _threshold) external {
         require(msg.sender == address(this), "Safe: self-call only");
         require(owner != address(0) && !isOwner[owner], "Safe: invalid or existing owner");
@@ -218,6 +245,11 @@ contract SentrixSafe {
         }
     }
 
+    /// @notice Remove an owner and optionally re-set the threshold.
+    /// @dev Audit L-Safe (LOW, 2026-05-13): same call-only constraint as
+    ///      addOwner. Must be invoked via execTransaction with
+    ///      operation=Operation.Call (operation=0); delegatecall would make
+    ///      msg.sender the owner EOA and fail the self-call guard.
     function removeOwner(address owner, uint256 _threshold) external {
         require(msg.sender == address(this), "Safe: self-call only");
         require(isOwner[owner], "Safe: not owner");

--- a/test/CoinBlastCurve.t.sol
+++ b/test/CoinBlastCurve.t.sol
@@ -244,23 +244,68 @@ contract CoinBlastCurveTest is Test {
 
     // ── Reentrancy ──────────────────────────────────────────────────
 
-    function test_reentrancy_buy_via_recipient_callback() public {
-        // Make the attacker contract BOTH buyer and feeRecipient so the
-        // fee-forward step (always non-zero) triggers receive() — the dust
-        // refund path is unreliable since binary search often lands on
-        // exact-match cost (no dust). Deploy a fresh curve with attacker
-        // as fee recipient.
-        CoinBlastCurve.InitParams memory p = _baseParams();
-        ReentrantBuyer attacker = new ReentrantBuyer(CoinBlastCurve(payable(address(0))));
-        p.feeRecipient = address(attacker);
-        CoinBlastCurve victim = new CoinBlastCurve(p);
-        attacker.setCurve(victim);
-        // Audit H5: don't pre-register the pair; only addLiquiditySRX (in the
-        // mock router) sets it now.
-
+    function test_reentrancy_sell_via_proceeds_callback() public {
+        // Audit M1 (2026-05-13): pre-fix the curve forwarded the fee to the
+        // recipient via .call which gave any malicious recipient a callback
+        // entry into buy()/sell(). Post-fix the fee is accrued (no callback)
+        // so the lock-vs-callback path is now via the seller's receive() on
+        // the sell-proceeds transfer. Verify the lock still trips: the
+        // attacker buys some tokens, then sells, and on receiving the
+        // sell-proceeds tries to re-enter buy() — must revert.
+        ReentrantSeller attacker = new ReentrantSeller(curve);
         vm.deal(address(attacker), 100 ether);
+        attacker.buyFirst(10 ether);
+
+        FactoryToken tok = curve.token();
+        uint256 bal = tok.balanceOf(address(attacker));
+        attacker.approveAll(bal);
+
         vm.expectRevert(CoinBlastCurve.TransferFailed.selector);
-        attacker.attack(10 ether);
+        attacker.sellAndReenter(bal);
+    }
+
+    // ── Audit M1: pull-pattern fee escrow ───────────────────────────
+
+    function test_fee_recipient_revert_does_not_break_buy() public {
+        // M1 (HIGH): a fee recipient that reverts on receive() must NOT be
+        // able to brick the curve. Pre-fix every buy/sell would revert at
+        // the .call{value:fee} step. Post-fix the fee is accrued — recipient
+        // bytecode has no influence on trade success.
+        CoinBlastCurve.InitParams memory p = _baseParams();
+        RevertingRecipient bad = new RevertingRecipient();
+        p.feeRecipient = address(bad);
+        CoinBlastCurve victim = new CoinBlastCurve(p);
+
+        vm.prank(alice);
+        victim.buy{value: 5 ether}(0);
+        // No revert = M1 fix working. Fee accrued for the bad recipient.
+        assertGt(victim.pendingFees(address(bad)), 0);
+    }
+
+    function test_fees_claim_drains_pending() public {
+        // Two buys, then the fee recipient pulls. Balance must equal
+        // pendingFees pre-claim, and pendingFees zero post-claim.
+        vm.prank(alice);
+        curve.buy{value: 5 ether}(0);
+        vm.prank(bob);
+        curve.buy{value: 3 ether}(0);
+
+        uint256 owed = curve.pendingFees(treasury);
+        assertGt(owed, 0);
+
+        uint256 before = treasury.balance;
+        vm.prank(treasury);
+        curve.claimFees();
+        assertEq(treasury.balance - before, owed);
+        assertEq(curve.pendingFees(treasury), 0);
+    }
+
+    function test_fees_claim_zero_reverts() public {
+        // Fresh recipient with no accrual.
+        address fresh = address(0x1234);
+        vm.prank(fresh);
+        vm.expectRevert(CoinBlastCurve.NoFeesToClaim.selector);
+        curve.claimFees();
     }
 
     // ── Graduation ──────────────────────────────────────────────────
@@ -368,11 +413,10 @@ contract CoinBlastCurveTest is Test {
     }
 }
 
-// Helper for the reentrancy test — buys then attempts to re-enter buy()
-// via the fee-recipient callback (curve always forwards a non-zero fee
-// when feeBps > 0, so this path is reliable; the SRX-dust refund path is
-// only triggered when binary search undershoots msg.value).
-contract ReentrantBuyer {
+// Helper: buys then sells, attempting to re-enter buy() via the
+// sell-proceeds callback. Audit M1 made the fee path pull-only, so this
+// is now the canonical reentry surface for sell().
+contract ReentrantSeller {
     CoinBlastCurve curve;
     bool reentered;
 
@@ -380,22 +424,33 @@ contract ReentrantBuyer {
         curve = c;
     }
 
-    function setCurve(CoinBlastCurve c) external {
-        curve = c;
+    function buyFirst(uint256 amount) external {
+        curve.buy{value: amount}(0);
     }
 
-    function attack(uint256 amount) external {
-        curve.buy{value: amount}(0);
+    function approveAll(uint256 amount) external {
+        FactoryToken(curve.token()).approve(address(curve), amount);
+    }
+
+    function sellAndReenter(uint256 tokens) external {
+        curve.sell(tokens, 0);
     }
 
     receive() external payable {
         if (!reentered) {
             reentered = true;
-            // Re-enter with a non-trivial amount so the inner buy() doesn't
-            // bail on ZeroValue before reaching the lock check. The inner
-            // call MUST revert with Reentrancy — that's what propagates back
-            // up as the curve's _safeSendSRX failure.
+            // Re-enter buy() with a non-trivial value. Inner call MUST revert
+            // with Reentrancy — that propagates as the outer curve's
+            // _safeSendSRX failure (TransferFailed).
             curve.buy{value: 1 ether}(0);
         }
+    }
+}
+
+// Helper: fee recipient that always reverts on receive. Pre-M1 this would
+// brick every buy/sell; post-M1 the fee is accrued so trades succeed.
+contract RevertingRecipient {
+    receive() external payable {
+        revert("nope");
     }
 }

--- a/test/Multicall3.t.sol
+++ b/test/Multicall3.t.sol
@@ -45,4 +45,21 @@ contract Multicall3Test is Test {
         assertEq(mc.getBlockNumber(), block.number);
         assertEq(mc.getChainId(), block.chainid);
     }
+
+    // Audit L-MC (LOW, 2026-05-13): non-Value variants must reject value.
+    function test_aggregate_rejects_msg_value() public {
+        Multicall3.Call[] memory calls = new Multicall3.Call[](1);
+        calls[0] = Multicall3.Call(address(target), abi.encodeWithSignature("getCounter()"));
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(bytes("Multicall3: use aggregate3Value to send native"));
+        mc.aggregate{value: 1 ether}(calls);
+    }
+
+    function test_aggregate3_rejects_msg_value() public {
+        Multicall3.Call3[] memory calls = new Multicall3.Call3[](1);
+        calls[0] = Multicall3.Call3(address(target), false, abi.encodeWithSignature("getCounter()"));
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(bytes("Multicall3: use aggregate3Value to send native"));
+        mc.aggregate3{value: 1 ether}(calls);
+    }
 }

--- a/test/Multicall3.t.sol
+++ b/test/Multicall3.t.sol
@@ -62,4 +62,22 @@ contract Multicall3Test is Test {
         vm.expectRevert(bytes("Multicall3: use aggregate3Value to send native"));
         mc.aggregate3{value: 1 ether}(calls);
     }
+
+    // CR follow-up 2026-05-14: blockAndAggregate + tryBlockAndAggregate
+    // were also payable. Same guard as aggregate / aggregate3.
+    function test_blockAndAggregate_rejects_msg_value() public {
+        Multicall3.Call[] memory calls = new Multicall3.Call[](1);
+        calls[0] = Multicall3.Call(address(target), abi.encodeWithSignature("getCounter()"));
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(bytes("Multicall3: use aggregate3Value to send native"));
+        mc.blockAndAggregate{value: 1 ether}(calls);
+    }
+
+    function test_tryBlockAndAggregate_rejects_msg_value() public {
+        Multicall3.Call[] memory calls = new Multicall3.Call[](1);
+        calls[0] = Multicall3.Call(address(target), abi.encodeWithSignature("getCounter()"));
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(bytes("Multicall3: use aggregate3Value to send native"));
+        mc.tryBlockAndAggregate{value: 1 ether}(calls);
+    }
 }

--- a/test/Safe.t.sol
+++ b/test/Safe.t.sol
@@ -188,6 +188,39 @@ contract SafeTest is Test {
         assertTrue(success);
     }
 
+    // ── Audit M-Safe: delegatecall-with-value rejection ─────
+
+    function test_exec_delegatecall_with_value_reverts() public {
+        // Audit M-Safe (MEDIUM, 2026-05-13): owners can sign over `value` for
+        // a delegatecall payload, but the DELEGATECALL opcode ignores value
+        // (executes in caller's context). Pre-fix the value was silently
+        // dropped → ExecutionSuccess emitted, no transfer, owners think it
+        // worked. Post-fix: explicit revert.
+        DelegateTarget target = new DelegateTarget();
+        bytes32 magic = bytes32(uint256(0xC0FFEE));
+        bytes memory data = abi.encodeCall(DelegateTarget.setHighSlot, (magic));
+
+        bytes32 txHash = safe.getTransactionHash(address(target), 1 ether, data, 1, safe.nonce());
+        bytes memory sigs = _sign2(txHash);
+
+        vm.expectRevert(SentrixSafe.DelegateCallWithValue.selector);
+        safe.execTransaction(address(target), 1 ether, data, 1, sigs);
+        // Whole tx reverted → nonce stays at 0 (storage rolled back).
+        assertEq(safe.nonce(), 0);
+    }
+
+    function test_exec_delegatecall_zero_value_still_works() public {
+        // Sanity: M-Safe rejects only value!=0; the well-trodden delegatecall
+        // path with value=0 must still succeed (regression guard).
+        DelegateTarget target = new DelegateTarget();
+        bytes32 magic = bytes32(uint256(0xBEEF));
+        bytes memory data = abi.encodeCall(DelegateTarget.setHighSlot, (magic));
+        bytes32 txHash = safe.getTransactionHash(address(target), 0, data, 1, safe.nonce());
+        bytes memory sigs = _sign2(txHash);
+        bool success = safe.execTransaction(address(target), 0, data, 1, sigs);
+        assertTrue(success);
+    }
+
     // ── execTransaction failure path — Audit H1 ─────────────
 
     function test_exec_revert_bubbles_inner_call_revert() public {


### PR DESCRIPTION
## Summary

Audit 2026-05-13 sweep — 1 HIGH + 3 MEDIUM + 2 LOW + 2 LOW NatSpec.

| Severity | Finding | File:line | Status |
| --- | --- | --- | --- |
| HIGH | CoinBlastCurve fee-recipient DoS (M1) | `contracts/CoinBlastCurve.sol:255,289` (pre-fix) | Fixed via pull-pattern escrow |
| MEDIUM | SentrixSafe delegatecall silent-value-drop (M-Safe) | `contracts/SentrixSafe.sol:118-139` (pre-fix) | Explicit revert added |
| MEDIUM | CoinBlastCurve sell balance drift (M2) | `contracts/CoinBlastCurve.sol:286-290` (pre-fix) | Balance clamp added |
| MEDIUM | CoinBlastCurve graduate min-args (M3) | `contracts/CoinBlastCurve.sol:335-346` (pre-fix) | Mins set to 1 |
| LOW | SentrixSafe ecrecover s/v hygiene (L-Safe) | `contracts/SentrixSafe.sol:173-184` | EIP-2 bound + v in {27,28} |
| LOW | Multicall3 stuck value on non-Value variants (L-MC) | `contracts/Multicall3.sol:36,51` | `require(msg.value == 0)` |
| LOW | MerkleAirdrop single-leaf-per-address NatSpec (L-MA) | `contracts/MerkleAirdrop.sol:78-93` | NatSpec added |
| LOW | SentrixSafe addOwner/removeOwner Call-only NatSpec | `contracts/SentrixSafe.sol:208,221` | NatSpec added |

### HIGH M1 — pull-pattern fees
Pre-fix: every buy/sell forwarded the fee directly to `feeRecipient` via `.call`. A reverting recipient (upgrade, SELFDESTRUCT-recreate, or future bug) bricked every trade on the curve forever.

Post-fix: fees accrue into `pendingFees[recipient]` and are pulled via `claimFees()`. New errors: `NoFeesToClaim()`. New events: `FeeAccrued`, `FeesClaimed`.

### MEDIUM M-Safe — delegatecall silent-value-drop
DELEGATECALL ignores msg.value (executes in caller context). Owners signing over `value` for a delegatecall got ExecutionSuccess with zero transfer. Now reverts with `DelegateCallWithValue()` when `operation==1 && value!=0`.

### MEDIUM M2 — sell balance clamp (H4-extended)
Buy/sell rounding can leave `address(this).balance < srxNet+fee` by ≤1 wei per trade. H4 (2026-05-07) clamped `srxRaised`; this clamps the actual transfer to available balance to prevent griefing-DoS via accumulated drift.

### MEDIUM M3 — graduate min-args
Pre-fix passed `tokenLiquidity` as both desired AND min, which would have rejected liquidity if the router applied any internal scaling. H5 guard already proves this curve is sole pair creator (`factory.getPair(token, wsrx) == 0`), so no slippage exposure exists. Pass `1` for both mins.

### LOW L-MC — Multicall3 divergence note
`aggregate()` and `aggregate3()` are upstream-payable but the per-call paths don't forward msg.value, so any SRX sent in is stranded (no withdraw path). Reject with explicit revert. **This means the deployed bytecode no longer matches the canonical 0xcA11... address — flagged in the contract NatSpec.**

## Test plan
- [x] `forge build` — succeeds, no new warnings.
- [x] `forge test` — 109 unit tests + 3 invariant tests pass (was 105 baseline; +5 new tests, 1 rewritten).
- [x] New tests:
  - `test_fee_recipient_revert_does_not_break_buy` — M1 anti-DoS regression.
  - `test_fees_claim_drains_pending`, `test_fees_claim_zero_reverts` — pull-pattern flow.
  - `test_reentrancy_sell_via_proceeds_callback` — replaces old fee-callback test (fee path no longer calls recipient; sell proceeds is now the canonical reentry surface).
  - `test_exec_delegatecall_with_value_reverts`, `test_exec_delegatecall_zero_value_still_works` — M-Safe rejection + regression guard.
  - `test_aggregate_rejects_msg_value`, `test_aggregate3_rejects_msg_value` — L-MC divergence guard.
- [x] Internal Sentrix Labs review before merge to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fee accrual now escrows trading fees and lets recipients claim owed fees.

* **Bug Fixes**
  * Sell flow hardened to avoid rounding/settlement reverts and ensure proceeds clamp safely.
  * Buys no longer break if a fee recipient reverts.
  * Batch-call entrypoints now reject unintended native value.
  * Delegatecall with non‑zero value is prohibited; signature checks tightened.

* **Documentation**
  * Added audit clarifications on airdrop claim behavior and other contract notes.

* **Tests**
  * Added coverage for fee claiming, sell‑reentrancy, multicall value guards, and delegatecall-with-value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/33)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->