### PR TITLE
build: one-shot publish — bypass tsup-DTS on TS 6, bypass pnpm gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/sentrix-labs/canonical-contracts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sentrix-labs/canonical-contracts.git"
+    "url": "git+https://github.com/sentrix-labs/canonical-contracts.git"
   },
   "type": "module",
   "main": "./dist/index.cjs",
@@ -37,9 +37,9 @@
     "test:sol": "forge test -vvv",
     "abi": "./script/copy-abi.sh",
     "gen": "node scripts/gen-types.mjs",
-    "build": "pnpm gen && tsup",
-    "typecheck": "tsc --noEmit",
-    "prepack": "pnpm build"
+    "build": "node scripts/gen-types.mjs && tsup && tsc --emitDeclarationOnly --declaration --declarationDir dist",
+    "prepack": "node scripts/gen-types.mjs && tsup && tsc --emitDeclarationOnly --declaration --declarationDir dist",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",
@@ -66,5 +66,10 @@
     "wagmi",
     "ethers",
     "blockchain"
-  ]
+  ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   // with every Node + bundler combo without forcing consumers to
   // care about extension routing.
   format: ["esm", "cjs"],
-  dts: true,
+  // tsup's --dts path is broken on TS 6.x (rollup-plugin-dts upstream gap,
+  // as of tsup 8.5.1 + typescript 6.0.3). We run `tsc --emitDeclarationOnly`
+  // after tsup instead — see the `build` script in package.json.
+  dts: false,
   sourcemap: true,
   clean: true,
   // ABIs are pure data — no need to bundle a runtime around them.


### PR DESCRIPTION
`npm publish` v1.1.0 needed manual workarounds because the build script hit two compat issues:

1. tsup 8.5.1's --dts path is broken on TypeScript 6.0.3 (rollup-plugin-dts upstream gap). The DTS step failed and we shipped v1.1.0 by running `tsc --emitDeclarationOnly` manually after tsup.

2. The `prepack: pnpm build` hook re-triggered pnpm 11's build-script approval gate during `npm publish`, blocking esbuild's postinstall. We had to drop prepack entirely to ship v1.1.0.

This commit closes both:

- tsup.config.ts: dts=false, with a comment pointing at the tsc step.
- package.json: `build` and `prepack` both call `node scripts/gen-types.mjs && tsup && tsc --emitDeclarationOnly --declaration --declarationDir dist` directly — no pnpm invocation in the path, so the approval gate never fires during publish.
- package.json: repository.url normalised to `git+https://...` to silence the `npm pkg fix` warning npm emitted on the v1.1.0 publish.

Verified end-to-end via `npm publish --dry-run`: prepack regenerates a clean dist/ with ESM + CJS bundles + .d.ts types, packs a 37-file 76.6kB tarball identical-in-shape to the published v1.1.0.

<!-- Brief one-line title above. -->

## Summary

What changed and why. 1-3 sentences.

## Scope

- [ ] Contract change (new file or logic edit) — needs slither pass + audit consideration
- [ ] Test-only change
- [ ] Deploy script / CI / docs only
- [ ] Repo tooling (Makefile, lefthook, etc.)

## Checks

- [ ] `forge build` clean
- [ ] `forge test` green (including fuzz + invariant)
- [ ] `forge fmt --check` clean
- [ ] `slither --no-fail-pedantic` reviewed (no new high-severity findings)
- [ ] Storage layout diff reviewed if any contract field added/removed (run `make storage` and inspect `docs/storage/*.json`)

## Linked issue

Closes #

## Deploy impact

- [ ] No on-chain change (test/CI/docs only)
- [ ] Requires v-bump + redeploy when shipped
- [ ] Backwards-compatible (extends, doesn't reorder storage)
- [ ] Breaking — needs migration plan in `RELEASES.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scripts to optimize TypeScript declaration generation workflow
  * Modified repository configuration and package build settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->