### PR TITLE
chore: release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Tag
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-05-26 — one-shot publish pipeline
+
+Build/CI-only release. No contract / ABI / address changes. Same `dist/` shape as v1.1.0 (37 files, ESM + CJS + `.d.ts`).
+
+### Build pipeline (#42)
+
+- **tsup `--dts` disabled** in `tsup.config.ts`. tsup 8.5.1 + TypeScript 6.0.3 hit a `rollup-plugin-dts` upstream gap during `npm publish`. We now emit `.d.ts` via a direct `tsc --emitDeclarationOnly` invocation after tsup produces the JS bundles.
+- **`build` and `prepack` scripts call binaries directly** (`node scripts/gen-types.mjs && tsup && tsc --emitDeclarationOnly --declaration --declarationDir dist`). No `pnpm` in the path, so pnpm 11's build-script approval gate never fires during `npm publish` and `esbuild`'s postinstall isn't blocked.
+- **`repository.url` normalised** to `git+https://...` to silence the `npm pkg fix` warning npm emitted on the v1.1.0 publish.
+
+v1.1.0 needed manual workarounds for both of those compat issues. v1.1.1 is the first one-shot publish (run `npm publish`, get a complete dist + tarball, no manual `tsc` or `tsup` invocation required).
+
 ### Documentation
 
 - **`docs/ADDRESSES.md`** — added "SentrixSafe ownership" section documenting the 2026-04-28 migration history and the final 1-of-1 state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentrix-labs/canonical-contracts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Canonical EVM contracts for Sentrix Chain (WSRX, Multicall3, SentrixSafe, TokenFactory). Typed ABIs + per-chain address registry for viem / ethers / wagmi.",
   "license": "BUSL-1.1",
   "homepage": "https://github.com/sentrix-labs/canonical-contracts",


### PR DESCRIPTION
Build/CI-only release. No contract / ABI / address changes. First one-shot publish using PR #42's fixed pipeline. CHANGELOG entry added.

## Test plan
- [x] `npm publish --dry-run` runs prepack cleanly; 37-file 79.1 kB tarball with ESM + CJS + .d.ts
- [x] No manual `tsc` / `tsup` invocation required
- [ ] Merge + run `npm publish` from main

## Risk tier
- [x] **🟢 Low** — version-string + CHANGELOG only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 1.1.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->