### PR TITLE
chore(readme): switch deploy examples to Foundry encrypted keystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,32 @@ Full integration guide → [`docs/INTEGRATION.md`](docs/INTEGRATION.md).
 End-to-end runbook: [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md). High-level flow:
 
 ```bash
+# 1. One-time: import the deployer key into Foundry's encrypted keystore.
+#    Prompts for the key + a passphrase; the key never lands in shell
+#    history, `ps aux`, or this README. Subsequent forge commands
+#    reference the account by name and Foundry prompts for the passphrase
+#    at use time.
+cast wallet import sentrix-deployer --interactive
+
+# 2. Per-network env (RPC URL aliases; safe to commit, no secrets).
 cp .env.example .env
 $EDITOR .env
 
-forge script script/DeployWSRX.s.sol --rpc-url sentrix_testnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
-forge script script/DeployWSRX.s.sol --rpc-url sentrix_mainnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
+# 3. Deploy.
+forge script script/DeployWSRX.s.sol --rpc-url sentrix_testnet --broadcast --account sentrix-deployer
+forge script script/DeployWSRX.s.sol --rpc-url sentrix_mainnet --broadcast --account sentrix-deployer
 
-# Update deployments/7119.json + 7120.json + CHANGELOG.md
-# Tag release
+# 4. Update deployments/7119.json + 7120.json + CHANGELOG.md
+# 5. Tag release
 git tag v1.0.0 && git push --tags
 ```
+
+> [!IMPORTANT]
+> Never deploy a production contract using `--private-key $HEX` on the
+> command line. The hex appears in shell history, `ps`, and any CI
+> logs that capture the invocation. Foundry's `cast wallet import` +
+> `--account <name>` keeps the key in `~/.foundry/keystores/` under
+> AES-128-CTR + scrypt and is the safer default.
 
 CI auto-creates a GitHub Release from the CHANGELOG entry.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,12 +5,27 @@ Step-by-step for a fresh `vX.Y.Z` deploy.
 ## 1. Prepare environment
 
 ```bash
+# One-time: import the deployer key into Foundry's encrypted keystore.
+# Prompts for the key + a passphrase. Key lands in ~/.foundry/keystores/
+# under AES-128-CTR + scrypt — not in shell history, not in `ps aux`,
+# not in CI logs that capture the invocation.
+cast wallet import sentrix-deployer --interactive
+
+# Per-network env (RPC URL aliases, public addresses, no secrets).
 cp .env.example .env
 $EDITOR .env
-# Fill in DEPLOYER_PRIVATE_KEY (no 0x prefix tolerated by foundry; both forms work)
 ```
 
-`.env` is gitignored. Rotate the deployer key after each release if you suspect exposure.
+`.env` is gitignored. The deployer key never lives in `.env`; it lives
+in the Foundry keystore created above. Rotate by re-running
+`cast wallet import` with a fresh secret + a new account name (or
+delete + re-import the existing name).
+
+> [!IMPORTANT]
+> Never deploy a production contract with `--private-key $HEX` on the
+> command line. The hex appears in shell history, `ps aux`, and any
+> CI log that captures the invocation. The `--account <name>` flow
+> below keeps every command secret-free.
 
 ## 2. Fund the deployer wallet
 
@@ -45,17 +60,17 @@ Must all pass before deploy.
 source .env
 
 forge script script/DeployWSRX.s.sol:DeployWSRX \
-  --rpc-url sentrix_testnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
+  --rpc-url sentrix_testnet --broadcast --account sentrix-deployer
 
 forge script script/DeployMulticall3.s.sol:DeployMulticall3 \
-  --rpc-url sentrix_testnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
+  --rpc-url sentrix_testnet --broadcast --account sentrix-deployer
 
 # Safe needs SAFE_OWNERS + SAFE_THRESHOLD env vars set
 forge script script/DeploySafe.s.sol:DeploySafe \
-  --rpc-url sentrix_testnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
+  --rpc-url sentrix_testnet --broadcast --account sentrix-deployer
 
 forge script script/DeployFactory.s.sol:DeployFactory \
-  --rpc-url sentrix_testnet --broadcast --private-key $DEPLOYER_PRIVATE_KEY
+  --rpc-url sentrix_testnet --broadcast --account sentrix-deployer
 ```
 
 After each deploy, capture: contract address, tx hash, block height, deployer address (the broadcast log prints them).
@@ -64,7 +79,7 @@ After each deploy, capture: contract address, tx hash, block height, deployer ad
 
 ```bash
 forge script script/CheckDeployment.s.sol:CheckDeployment \
-  --rpc-url sentrix_testnet --private-key $DEPLOYER_PRIVATE_KEY
+  --rpc-url sentrix_testnet --account sentrix-deployer
 ```
 
 Should report `OK` for every contract. Any `MISMATCH` or `UNREACHABLE` = stop, investigate before mainnet.


### PR DESCRIPTION
## Summary

Previous deploy snippet shipped two `forge script … --private-key $DEPLOYER_PRIVATE_KEY` lines side by side. Even wrapped in an env var, that pattern lands the hex in shell history, `ps aux`, and any CI log that captures the invocation — exactly the operational mistake a canonical-contracts README should not model.

Replaced with the Foundry encrypted-keystore flow:

```bash
cast wallet import sentrix-deployer --interactive
forge script ... --account sentrix-deployer
```

Key lives under `~/.foundry/keystores/` (AES-128-CTR + scrypt). Foundry prompts for the passphrase at use time; the deploy command line contains no secret material.

Plus an explicit `> [!IMPORTANT]` callout warning against falling back to `--private-key` under time pressure.

## Why this matters

A canonical-contracts repo is the first place a new dApp dev looks for a copy-pasteable deploy recipe. Whatever shape ships in this README sets the precedent for every downstream Foundry project on Sentrix. Recommending raw hex would compound bad ops hygiene across the ecosystem.

## Test plan

- [x] No contract / Solidity change
- [x] No runtime behavior affected
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised deployment runbook to use Foundry keystore for managing deployer credentials instead of command-line private key arguments.
  * Added security guidance for the deployment process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/canonical-contracts/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->